### PR TITLE
Fixed broken demo with onInit not being called.

### DIFF
--- a/SKStatefulTableViewController/SKStatefulTableViewController.m
+++ b/SKStatefulTableViewController/SKStatefulTableViewController.m
@@ -48,6 +48,13 @@ typedef enum {
   return self;
 }
 
+- (id)init {
+  if ((self = [super init])) {
+    [self onInit];
+  }
+  return self;
+}
+
 - (void)onInit {
   self.statefulDelegate = self;
   self.loadMoreTriggerThreshold = 64.f;


### PR DESCRIPTION
The demo wasn't working at all for me in Xcode 7. I looked into it and it was because the `onInit` method wasn't being called for the `DMBasicViewController` classes since they were being initialized with the `init` method.
