### PR TITLE
Add support for Dynamic Type to reload the table

### DIFF
--- a/SKStatefulTableViewController/SKStatefulTableViewController.h
+++ b/SKStatefulTableViewController/SKStatefulTableViewController.h
@@ -63,6 +63,9 @@ typedef enum {
 @property (nonatomic) BOOL canLoadMore;
 @property (strong, nonatomic) NSError *lastLoadMoreError;
 
+// Should register for dynamic text changes
+@property (nonatomic) BOOL shouldMonitorContentSize;
+
 - (void)onInit;
 
 - (void)setStatefulState:(SKStatefulTableViewControllerState)state withError:(NSError *)error;

--- a/SKStatefulTableViewController/SKStatefulTableViewController.m
+++ b/SKStatefulTableViewController/SKStatefulTableViewController.m
@@ -64,6 +64,11 @@ typedef enum {
   self.loadMoreTriggerThreshold = 64.f;
   self.canLoadMore = YES;
   self.canPullToRefresh = YES;
+  self.shouldMonitorContentSize = NO;
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)viewDidLoad {
@@ -89,6 +94,10 @@ typedef enum {
       UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleHeight;
   [self.tableView addSubview:staticContentView];
   self.staticContainerView = staticContentView;
+
+  if (self.shouldMonitorContentSize) {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];
+  }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -478,6 +487,14 @@ typedef enum {
 - (UITableViewCell *)tableView:(UITableView *)tableView
          cellForRowAtIndexPath:(NSIndexPath *)indexPath {
   return nil;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Notifications
+- (void)contentSizeCategoryDidChange:(NSNotification *)notification {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self.tableView reloadData];
+  });
 }
 
 @end


### PR DESCRIPTION
Add `shouldMonitorContentSize` property.

This property allows for the observation of the `UIContentSizeCategoryDidChangeNotification` notification to reload the table when the user changes their preferences for Dynamic Text.
